### PR TITLE
Add Laravel 13 support and PHP 8.5 CI coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,10 +9,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.3, 8.2, 8.1]
-        laravel: ["^12.0", "^11.0", "^10.0"]
+        php: [8.5, 8.3, 8.2, 8.1]
+        laravel: ["^13.0", "^12.0", "^11.0", "^10.0"]
         dependency-version: [prefer-stable]
         include:
+          - laravel: "^13.0"
+            testbench: 11.*
           - laravel: "^12.0"
             testbench: 10.*
           - laravel: "^11.0"
@@ -24,6 +26,14 @@ jobs:
             php: 8.1
           - laravel: "^11.0"
             php: 8.1
+          - laravel: "^13.0"
+            php: 8.1
+          - laravel: "^13.0"
+            php: 8.2
+          - laravel: "^10.0"
+            php: 8.5
+          - laravel: "^11.0"
+            php: 8.5
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
   },
   "require": {
     "php": ">=8.1",
-    "laravel/framework": "^10.0|^11.0|^12.0",
+    "laravel/framework": "^10.0|^11.0|^12.0|^13.0",
     "laravel/helpers": "^1.6",
     "spatie/laravel-data": "^4.17",
     "spatie/laravel-typescript-transformer": "^2.5"
@@ -47,7 +47,7 @@
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.8",
     "larastan/larastan": "^2.1|^3.0",
-    "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
+    "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0|^11.0",
     "phpunit/phpunit": "^9.0|^10.0|^11.0"
   },
   "extra": {


### PR DESCRIPTION
- Add `^13.0` to `laravel/framework` and `^11.0` to `orchestra/testbench` (additive; keeps Laravel 10-12).
- CI: add Laravel 13 to the matrix (testbench `11.*`) and add PHP 8.5; exclude older Laravel on 8.5.
- All 40 tests pass on PHP 8.5 + Laravel 13.14.